### PR TITLE
Separate app configuration into a new config module

### DIFF
--- a/src/cli_base.ts
+++ b/src/cli_base.ts
@@ -1,5 +1,6 @@
 import { parseArgs } from "util";
 import { execute } from "./index.ts";
+import { updateConfig } from "./config.ts";
 
 const { values } = parseArgs({
   args: Bun.argv.slice(2), // Skip 'bun' and script name
@@ -32,11 +33,6 @@ if (
   process.exit(1);
 }
 
-const optionalArgs = { rounds: values.rounds };
+updateConfig(values);
 
-await execute({
-  demoPath: values.demoPath!,
-  outputDir: values.outputDir!,
-  playerId: values.userId!,
-  optionalArgs: optionalArgs
-});
+await execute();

--- a/src/cli_interactive.ts
+++ b/src/cli_interactive.ts
@@ -5,6 +5,7 @@ import path from "path";
 import * as readline from "readline";
 import { execute } from "./index.ts";
 import { checkDeps } from "./utils/os/checkDeps.ts";
+import { updateConfig } from "./config.ts";
 
 // Helper function to open files/directories cross-platform
 const openPath = async (path: string) => {
@@ -157,6 +158,7 @@ async function main() {
   // Make sure output directory exists
   await $`mkdir -p ${outputDir}`;
 
+  updateConfig({ demoPath, outputDir, userId: playerId, rounds });
   console.log(`\n✅ Configuration:`);
   console.log(`Demo Path: ${demoPath}`);
   console.log(`Output Directory: ${outputDir}`);
@@ -164,7 +166,7 @@ async function main() {
 
   console.log("\n🚀 Starting processing...");
   const outputFilePath = path.normalize(
-    await execute({ demoPath, outputDir, playerId, optionalArgs: {rounds} })
+    await execute()
   );
 
   // console.log("\n✅ Complete! Press any key to exit...");

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,43 @@
+interface AppConfig {
+  demoPath: string;
+  outputDir: string;
+  userId: string;
+  rounds: string;
+  selfRun: boolean;
+}
+
+let currentConfig: Partial<AppConfig> = {
+  demoPath: undefined,
+  outputDir: undefined,
+  userId: undefined,
+  rounds: "",
+  selfRun: false
+}
+
+const REQUIRED_KEYS: Array<keyof AppConfig> = ['demoPath', 'outputDir', 'userId'];
+
+function validateConfig(currentConfig: Partial<AppConfig>): asserts currentConfig is AppConfig {
+  const missingKeys: Array<keyof AppConfig> = [];
+
+  for (const key of REQUIRED_KEYS) {
+    if (currentConfig[key] === undefined || currentConfig[key] === null || currentConfig[key] ===  "") {
+      missingKeys.push(key);
+    }
+  }
+
+  if (missingKeys.length > 0) {
+    throw new Error(
+      `Configuration Error: The following required keys are missing or undefined: ${missingKeys.join(', ')}`
+    );
+  }
+}
+
+export const getConfig = (): Readonly<AppConfig> => {
+  validateConfig(currentConfig);
+
+  return currentConfig as AppConfig;
+};
+
+export const updateConfig = (newSettings: Partial<AppConfig>): void => {
+  currentConfig = { ...currentConfig, ...newSettings };
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,19 @@ export const getConfig = (): Readonly<AppConfig> => {
   return currentConfig as AppConfig;
 };
 
+function filterUndefinedValues<T extends Record<string, any>>(settings: T): Partial<T> {
+  return Object.keys(settings).reduce((acc, key) => {
+    const value = settings[key];
+    if (value !== undefined && value !== null) {
+      // Keep false, 0, "", or any other defined value
+      acc[key as keyof T] = value;
+    }
+    return acc;
+  }, {} as Partial<T>);
+}
+
 export const updateConfig = (newSettings: Partial<AppConfig>): void => {
-  currentConfig = { ...currentConfig, ...newSettings };
+  const definedSettings = filterUndefinedValues(newSettings);
+
+  currentConfig = { ...currentConfig, ...definedSettings };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { checkDeps } from "./utils/os/checkDeps";
 import { cleanupAfterConcat } from "./utils/os/cleanup";
 import { concatOverlayClips } from "./utils/video/concat";
 import { buildRunsForClip, burnOverlayForClip } from "./utils/video/overlay";
+import { getConfig } from "./config";
 
 const getPlayerNumbers = (
   demoPath: string
@@ -278,18 +279,13 @@ const recordSequences = async ({
   return recordedSequences;
 };
 
-const execute = async ({
-  playerId,
-  demoPath,
-  outputDir,
-  optionalArgs
-}: {
-  playerId: string;
-  demoPath: string;
-  outputDir: string;
-  optionalArgs: Dict<string>;
-}): Promise<string> => {
+const execute = async (): Promise<string> => {
   await checkDeps();
+
+  const config = getConfig();
+  const demoPath = config.demoPath;
+  const outputDir = config.outputDir;
+  const playerId = config.userId;
 
   const now = Date.now();
   // Confirm demo exists in csdm
@@ -303,7 +299,7 @@ const execute = async ({
   });
   console.log(`Found ${sequences.length} sequences`);
 
-  const roundFilter = optionalArgs["rounds"]?.split(',').map(Number);
+  const roundFilter = config["rounds"].split(',').map(Number);
   const requestSequences = filterSequences({sequences, roundFilter});
   console.log(`${requestSequences.length} rounds to be recorded`);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -303,6 +303,11 @@ const execute = async (): Promise<string> => {
   const requestSequences = filterSequences({sequences, roundFilter});
   console.log(`${requestSequences.length} rounds to be recorded`);
 
+  if (requestSequences.length == 0) {
+    console.log(`Nothing to record. Process took ${(Date.now() - now) / 1000}s`);
+    return "";
+  }
+
   console.log(`Recording sequences to: ${outputDir}`);
   const recordedSequences = await recordSequences({
     demoPath,


### PR DESCRIPTION
I wanted to add hide inactive overlay option and I run into an issue that we need to pass the options through multiple functions. To fix it I propose moving config stuff into its own module. This way we can also ensure config integrity, by checking if important keys are set before we return the config.

@amorijs pls take a look at `config.ts`, I tried to be super secure with both get and update, but I don't have any real TS experience and I'm kind of learning this language writing this code 😄 